### PR TITLE
Github actions docker build cache

### DIFF
--- a/.github/workflows/docker-multi-platform.yml
+++ b/.github/workflows/docker-multi-platform.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - docker-build-github-action
     tags:
       - "v*.*.*"
 
@@ -12,16 +13,29 @@ env:
   IMAGE_VERSION: ${{ github.ref_name }}
 
 jobs:
-  build:
+  set-matrix:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      # Only run the arm64 (mac m1) build on tagged releases, since it takes so long to run
+      - id: set-matrix
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo 'matrix=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF_TYPE}" == "branch" && ("${GITHUB_REF_NAME}" == "master" || "${GITHUB_REF_NAME}" == "docker-build-github-action") ]]; then
+            echo 'matrix=["linux/amd64"]' >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Unrecognized ref type or branch. Ref type: ${GITHUB_REF_TYPE}, Ref name: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+  build:
+    needs: set-matrix
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        platform: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/docker-multi-platform.yml
+++ b/.github/workflows/docker-multi-platform.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - docker-build-github-action
-
     tags:
       - "v*.*.*"
 
@@ -24,7 +22,7 @@ jobs:
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             echo 'matrix=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_REF_TYPE}" == "branch" && ("${GITHUB_REF_NAME}" == "master" || "${GITHUB_REF_NAME}" == "docker-build-github-action") ]]; then
+          elif [[ "${GITHUB_REF_TYPE}" == "branch" && "${GITHUB_REF_NAME}" == "master" ]]; then
             echo 'matrix=["linux/amd64"]' >> $GITHUB_OUTPUT
           else
             echo "ERROR: Unrecognized ref type or branch. Ref type: ${GITHUB_REF_TYPE}, Ref name: ${GITHUB_REF_NAME}" >&2

--- a/.github/workflows/docker-multi-platform.yml
+++ b/.github/workflows/docker-multi-platform.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - docker-build-github-action
+
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/docker-multi-platform.yml
+++ b/.github/workflows/docker-multi-platform.yml
@@ -33,6 +33,8 @@ jobs:
   build:
     needs: set-matrix
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         platform: ${{ fromJson(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/docker-multi-platform.yml
+++ b/.github/workflows/docker-multi-platform.yml
@@ -85,8 +85,8 @@ jobs:
           file: web-app/pontoon/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=pontoon-frontend
+          cache-to: type=gha,mode=max,scope=pontoon-frontend
           outputs: type=image,name=${{ env.REGISTRY }}/pontoon-frontend,push-by-digest=true,name-canonical=true,push=true
 
       # Build and push api
@@ -98,8 +98,8 @@ jobs:
           file: api/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=pontoon-api
+          cache-to: type=gha,mode=max,scope=pontoon-api
           outputs: type=image,name=${{ env.REGISTRY }}/pontoon-api,push-by-digest=true,name-canonical=true,push=true
 
       # Build and push worker
@@ -111,8 +111,8 @@ jobs:
           file: data-transfer/pontoon/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=pontoon-worker
+          cache-to: type=gha,mode=max,scope=pontoon-worker
           outputs: type=image,name=${{ env.REGISTRY }}/pontoon-worker,push-by-digest=true,name-canonical=true,push=true
 
       # Build and push beat
@@ -124,8 +124,8 @@ jobs:
           file: data-transfer/pontoon/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=pontoon-beat
+          cache-to: type=gha,mode=max,scope=pontoon-beat
           outputs: type=image,name=${{ env.REGISTRY }}/pontoon-beat,push-by-digest=true,name-canonical=true,push=true
 
       # Build and push unified image
@@ -137,8 +137,8 @@ jobs:
           file: Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=pontoon-unified
+          cache-to: type=gha,mode=max,scope=pontoon-unified
           outputs: type=image,name=${{ env.REGISTRY }}/pontoon-unified,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             API_IMAGE=${{ env.REGISTRY }}/pontoon-api@${{ steps.build-api.outputs.digest }}


### PR DESCRIPTION
- Fixes the docker build cache so that the cache is scoped for each image
- Speeds up a fully cached build from 10 minutes to 1.5 minutes on amd64
- Only build arm64 (mac m1) docker images on tagged runs since those builds take ~4x longer