### PR TITLE
Upgrade and pin unified container's postgres version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && \
     apt-get install -y \
     supervisor \
     redis-server \
-    postgresql \
-    postgresql-client \
+    postgresql-17 \
+    postgresql-client-17 \
     gcc \
     libpq-dev \
     curl \ 
@@ -83,7 +83,7 @@ ENV POSTGRES_USER=dev
 ENV POSTGRES_PASSWORD=dev
 ENV POSTGRES_DATABASE=pontoon
 
-ENV PATH="/usr/lib/postgresql/15/bin:$PATH"
+ENV PATH="/usr/lib/postgresql/17/bin:$PATH"
 RUN mkdir -p /var/lib/postgresql/data && \
     chown -R postgres:postgres /var/lib/postgresql
 USER postgres

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon=true
 
 [program:postgres]
 user=postgres
-command=/usr/lib/postgresql/15/bin/postgres -D /var/lib/postgresql/data
+command=/usr/lib/postgresql/17/bin/postgres -D /var/lib/postgresql/data
 stdout_logfile=/var/log/postgres.log
 stderr_logfile=/var/log/postgres.log
 autostart=true


### PR DESCRIPTION
- Upgrade unified container's internal postgres version from 15 to 17 (docker compose is already on 17)
- Pin the postgres version in the unified dockerfile

- NOTE: If all these following conditions are true for you, then you will need to run `pg_upgrade` to upgrade the internal postgres instance (see https://www.postgresql.org/docs/current/upgrading.html):
1. You use are using the `pontoon-unified` container
2. You are NOT using an external postgres db (we recommend using an external postgres db for production deployments)
3. You want to keep the existing data for your pontoon instance