### PR TITLE
Revamped destination and transfer pages

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -20,17 +20,17 @@ RUN apt-get update \
     && apt-get -y install libpq-dev gcc \
     && pip install psycopg2
 
+# Copy and install the transfer library wheel
+COPY --from=transfer-builder /transfer-build/dist/*.whl /api/dist/
+RUN pip install --no-cache-dir /api/dist/pontoon-*.whl
+
 # Build the API app
 COPY ./api/pyproject.toml /api/pyproject.toml
 COPY ./api/app /api/app
 COPY ./api/db /api/db
 RUN pip install build && python -m build --wheel
 
-# Copy the transfer library wheel into dist
-COPY --from=transfer-builder /transfer-build/dist/*.whl /api/dist/
-
 RUN pip install --no-cache-dir /api/dist/app-*.whl
-RUN pip install --no-cache-dir /api/dist/pontoon-*.whl
 RUN pip install SQLAlchemy==2.0.41
 
 EXPOSE 8000

--- a/api/app/routers/transfers.py
+++ b/api/app/routers/transfers.py
@@ -79,6 +79,9 @@ def rerun_transfer(
             raise TransferRun.Exception("Transfer run does not have arguments; can't re-run")
 
         args = meta.get('arguments', {})
+        execution_id = meta.get('execution_id', None)
+        if execution_id is None:
+            raise TransferRun.Exception("Transfer run does not have an execution ID; can't re-run")
 
         # kick off a new transfer
         if settings.skip_transfers != True:
@@ -88,6 +91,7 @@ def rerun_transfer(
             new_run.set_destination(str(destination.destination_id))
             new_run.set_mode(Mode(args.get('mode', {})))
             new_run.set_models(args.get('models', []))
+            new_run.set_execution_id(execution_id)
             new_run.run(expedited=False)
 
         return {"ok": True}

--- a/api/app/routers/transfers.py
+++ b/api/app/routers/transfers.py
@@ -27,11 +27,12 @@ Transfer.configure(
 @router.get("", response_model=list[TransferRun.Model])
 def search_transfers(
         destination_id: uuid.UUID,
+        execution_id: uuid.UUID = None,
         session = Depends(get_session),
         offset: int = 0,
         limit: Annotated[int, Query(le=100)] = 100,
 ):
-    return TransferRun.list(session, destination_id, offset, limit)
+    return TransferRun.list(session, offset=offset, limit=limit, destination_id=destination_id, execution_id=execution_id)
 
 
 @router.get("/{transfer_run_id}", response_model=TransferRun.Model)
@@ -43,6 +44,16 @@ def get_transfer_run(
     if not transfer_run:
         raise HTTPException(status_code=404, detail="Transfer run not found")
     return transfer_run
+
+@router.get("/transfer/{transfer_id}", response_model=TransferModel.Model)
+def get_transfer(
+    transfer_id: uuid.UUID,
+    session = Depends(get_session),
+):
+    transfer = TransferModel.get(session, transfer_id)
+    if not transfer:
+        raise HTTPException(status_code=404, detail="Transfer not found")
+    return transfer
 
 
 @router.post("/{transfer_run_id}/rerun")

--- a/data-transfer/pontoon/pontoon/celery/tasks.py
+++ b/data-transfer/pontoon/pontoon/celery/tasks.py
@@ -15,7 +15,9 @@ def transfer_task(self, args_json: str):
     print("Running transfer job as celery task...")
     try:
         args = json.loads(args_json).get('commandArgs', [])
-        args += ['--execution-id', str(self.request.id)]
+        if '--execution-id' not in args:
+            # Generate a new execution ID if one is not provided
+            args += ['--execution-id', str(self.request.id)]
         args += ['--retry-count', str(self.request.retries)]
         args += ['--retry-limit', str(TASK_MAX_RETRIES)]
 

--- a/data-transfer/pontoon/pontoon/orchestration/client.py
+++ b/data-transfer/pontoon/pontoon/orchestration/client.py
@@ -369,6 +369,10 @@ class Transfer:
     def set_organization(self, organization_id:str) -> 'Transfer':
         # set the org id for this transfer
         return self.set_argument('--organization-id', organization_id)
+    
+    def set_execution_id(self, execution_id:str) -> 'Transfer':
+        # set the execution id for this transfer
+        return self.set_argument('--execution-id', execution_id)
 
 
     def set_argument(self, arg_name:str, arg_value) -> 'Transfer':

--- a/data-transfer/pontoon/pontoon/orchestration/transfer.py
+++ b/data-transfer/pontoon/pontoon/orchestration/transfer.py
@@ -219,7 +219,9 @@ class TransferCommand(Command):
         schedule_hour = schedule.get('hour', 0)
         schedule_min = schedule.get('minute', 0)
 
-        end_time = self._now.replace(hour=schedule_hour, minute=schedule_min, microsecond=0)
+        end_time = self._now.replace(minute=schedule_min, second=0, microsecond=0)
+        if period != Mode.HOURLY:
+            end_time = end_time.replace(hour=schedule_hour)
         
         if period == Mode.WEEKLY:
             begin_time = end_time - timedelta(days=7, hours=12)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - app-network
     depends_on:
       - redis
+    restart: unless-stopped
 
 volumes:
   postgres-data:

--- a/test-env/mock_data_generator.py
+++ b/test-env/mock_data_generator.py
@@ -191,11 +191,12 @@ def generate_and_insert_mock_data():
     conn = get_db_connection()
     try:
         logger.info("Starting mock data generation...")
+        num_records_to_generate = 50
         
         # Generate mock data
-        leads = generate_mock_leads(100)
-        campaigns = generate_mock_campaigns(100)
-        attributions = generate_mock_attribution(100)
+        leads = generate_mock_leads(num_records_to_generate)
+        campaigns = generate_mock_campaigns(num_records_to_generate)
+        attributions = generate_mock_attribution(num_records_to_generate)
         
         # Insert data
         insert_leads(conn, leads)
@@ -217,8 +218,8 @@ def main():
     while True:
         try:
             generate_and_insert_mock_data()
-            logger.info("Waiting 5 minutes before next generation...")
-            time.sleep(300)  # 5 minutes
+            logger.info("Waiting 1 minute before next generation...")
+            time.sleep(60)  # 1 minute
         except KeyboardInterrupt:
             logger.info("Mock data generator stopped by user")
             break

--- a/web-app/pontoon/package-lock.json
+++ b/web-app/pontoon/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/lab": "^7.0.0-beta.14",
         "@mui/material": "^7.2.0",
         "@mui/material-nextjs": "^7.2.0",
+        "@mui/x-date-pickers": "^8.10.2",
         "@tabler/icons-react": "^3.34.0",
         "dayjs": "^1.11.13",
         "formik": "^2.4.6",
@@ -119,9 +120,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1283,12 +1284,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-p63yhbX52MO/ajXC7hDHJA5yjzJekvWD3q4YDLl1rSg+OXLczMYPvTuSuviPRCgRX8+E42RXz1D/dz9SxPSlWg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.5.tgz",
+      "integrity": "sha512-ZPwlAOE3e8C0piCKbaabwrqZbW4QvWz0uapVPWya7fYj6PeDkl5sSJmomT7wjOcZGPB48G/a6Ubidqreptxz4g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6"
+        "@babel/runtime": "^7.28.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1300,17 +1301,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-O0i1GQL6MDzhKdy9iAu5Yr0Sz1wZjROH1o3aoztuivdCXqEeQYnEjTDiRLGuFxI9zrUbTHBwobMyQH5sNtyacw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.1.tgz",
+      "integrity": "sha512-/31y4wZqVWa0jzMnzo6JPjxwP6xXy4P3+iLbosFg/mJQowL1KIou0LC+lquWW60FKVbKz5ZUWBg2H3jausa0pw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "@mui/types": "^7.4.4",
+        "@babel/runtime": "^7.28.2",
+        "@mui/types": "^7.4.5",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.1.0"
+        "react-is": "^19.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1330,10 +1331,98 @@
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.10.2.tgz",
+      "integrity": "sha512-eS5t1jUojN/jL2FeJ8gtpCBxIEswUp9kLjM64aJ5LUKrNgM7X9dwsEHyplS+x07kWLiEAhO3nX3mepnS3Z43qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "@mui/x-internals": "8.10.2",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.10.2.tgz",
+      "integrity": "sha512-dlC0BQRRBdiWtqn1yDppaHYRUjU3OuPWTxy0UtqxDaJjJf4pfR8ALr243nbxgJAFqvQyWPWyO4A6p9x9eJMJEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -5363,6 +5452,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/web-app/pontoon/package.json
+++ b/web-app/pontoon/package.json
@@ -16,6 +16,7 @@
     "@mui/lab": "^7.0.0-beta.14",
     "@mui/material": "^7.2.0",
     "@mui/material-nextjs": "^7.2.0",
+    "@mui/x-date-pickers": "^8.10.2",
     "@tabler/icons-react": "^3.34.0",
     "dayjs": "^1.11.13",
     "formik": "^2.4.6",

--- a/web-app/pontoon/src/app/api/requests.js
+++ b/web-app/pontoon/src/app/api/requests.js
@@ -130,5 +130,25 @@ export async function rerunTransferRequest(key, { arg }) {
 }
 
 export async function runDestinationRequest(key, { arg }) {
-  return postRequest(`/destinations/${arg}/run`, { arg: {} });
+  const { destinationId, scheduleOverride } = arg;
+
+  // Prepare the request body based on the schedule override
+  let requestBody = {};
+  if (scheduleOverride && scheduleOverride.backfillType) {
+    requestBody.type = scheduleOverride.backfillType;
+
+    if (
+      scheduleOverride.backfillType === "INCREMENTAL" &&
+      scheduleOverride.startTime &&
+      scheduleOverride.endTime
+    ) {
+      // startTime and endTime are already ISO strings from the frontend
+      requestBody.start = scheduleOverride.startTime;
+      requestBody.end = scheduleOverride.endTime;
+    }
+  }
+
+  return postRequest(`/destinations/${destinationId}/run`, {
+    arg: requestBody,
+  });
 }

--- a/web-app/pontoon/src/app/api/requests.js
+++ b/web-app/pontoon/src/app/api/requests.js
@@ -9,6 +9,7 @@ export async function getRequest(url) {
       const error = new Error(
         "An error occurred while fetching the data: " + url
       );
+      console.log(res);
       // Attach extra info to the error object.
       error.info = await res.json();
       error.status = res.status;

--- a/web-app/pontoon/src/app/api/requests.js
+++ b/web-app/pontoon/src/app/api/requests.js
@@ -9,7 +9,6 @@ export async function getRequest(url) {
       const error = new Error(
         "An error occurred while fetching the data: " + url
       );
-      console.log(res);
       // Attach extra info to the error object.
       error.info = await res.json();
       error.status = res.status;
@@ -130,7 +129,7 @@ export async function rerunTransferRequest(key, { arg }) {
 }
 
 export async function runDestinationRequest(key, { arg }) {
-  const { destinationId, scheduleOverride } = arg;
+  const { scheduleOverride } = arg;
 
   // Prepare the request body based on the schedule override
   let requestBody = {};
@@ -148,7 +147,7 @@ export async function runDestinationRequest(key, { arg }) {
     }
   }
 
-  return postRequest(`/destinations/${destinationId}/run`, {
+  return postRequest(key, {
     arg: requestBody,
   });
 }

--- a/web-app/pontoon/src/app/components/forms/FormRadioGroup.js
+++ b/web-app/pontoon/src/app/components/forms/FormRadioGroup.js
@@ -1,0 +1,43 @@
+import React from "react";
+import {
+  Typography,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  FormHelperText,
+  Stack,
+} from "@mui/material";
+import { useField } from "formik";
+
+const FormRadioGroup = ({ titleText, helperText, options = [], ...props }) => {
+  const [field, meta] = useField(props);
+  return (
+    <Stack>
+      <Typography
+        htmlFor={props.id || props.name}
+        sx={{ fontWeight: 600, marginBottom: "4px" }}
+      >
+        {titleText}
+      </Typography>
+      <FormControl error={meta.touched && meta.error} fullWidth>
+        <RadioGroup {...field} {...props} row>
+          {options.map((option) => (
+            <FormControlLabel
+              key={option.value}
+              value={option.value}
+              control={<Radio />}
+              label={option.label}
+            />
+          ))}
+        </RadioGroup>
+      </FormControl>
+      {meta.touched && meta.error ? (
+        <FormHelperText error>{meta.error}</FormHelperText>
+      ) : null}
+      <FormHelperText>{helperText}</FormHelperText>
+    </Stack>
+  );
+};
+
+export default FormRadioGroup;

--- a/web-app/pontoon/src/app/destinations/[id]/page.js
+++ b/web-app/pontoon/src/app/destinations/[id]/page.js
@@ -255,7 +255,9 @@ const TransferTable = ({ schedule, id }) => {
     isLoading: transfersLoading,
     isValidating: transfersValidating,
     mutate: mutateTransfers,
-  } = useSWR(`/transfers?destination_id=${id}`, getRequest);
+  } = useSWR(`/transfers?destination_id=${id}`, getRequest, {
+    refreshInterval: 3000,
+  });
 
   const { trigger: triggerRerunTransfer } = useSWRMutation(
     `/transfers/:id/rerun`,

--- a/web-app/pontoon/src/app/destinations/[id]/page.js
+++ b/web-app/pontoon/src/app/destinations/[id]/page.js
@@ -269,18 +269,6 @@ const TransferTable = ({ schedule, id }) => {
     runDestinationRequest
   );
 
-  // const refreshTransfers = () => {
-  //   mutateTransfers();
-  // };
-
-  // const autoRefresh = () => {
-  //   const intervalId = setInterval(refreshTransfers, 3000);
-  //   // Stop after 5 min
-  //   setTimeout(() => {
-  //     clearInterval(intervalId);
-  //   }, 60000 * 5);
-  // };
-
   const rerunTransfer = async (transferRunId) => {
     triggerRerunTransfer(transferRunId);
     setOpenSuccess(true);
@@ -428,11 +416,6 @@ const TransferTable = ({ schedule, id }) => {
                 Data Transfer Interval
               </Typography>
             </TableCell>
-            {/* <TableCell>
-              <Typography variant="subtitle2" fontWeight={600}>
-                Data Transfer Interval End
-              </Typography>
-            </TableCell> */}
             <TableCell
               sx={{
                 padding: "0",
@@ -506,7 +489,7 @@ const TransferTable = ({ schedule, id }) => {
                         : ""}
                       {transfer.scheduled_at
                         ? dayjs(transfer.scheduled_at)
-                            .format("ddd, MMM D, h:mm A z")
+                            .format("MMM D, h:mm A z")
                             .toString()
                         : ""}
                     </Typography>
@@ -563,25 +546,6 @@ const TransferTable = ({ schedule, id }) => {
                     </Typography>
                   </TableCell>
 
-                  {/* <TableCell>
-                    <Typography noWrap variant="subtitle2" fontWeight={600}>
-                      {transfer?.meta?.arguments?.mode?.start
-                        ? dayjs(transfer.meta.arguments.mode.start)
-                            .format("MMM D, h:mm A z")
-                            .toString()
-                        : ""}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography noWrap variant="subtitle2" fontWeight={600}>
-                      {transfer?.meta?.arguments?.mode?.end
-                        ? dayjs(transfer.meta.arguments.mode.end)
-                            .format("MMM D, h:mm A z")
-                            .toString()
-                        : ""}
-                    </Typography>
-                  </TableCell> */}
-
                   <TableCell align="right">
                     {(transfer.status == "SUCCESS" ||
                       transfer.status == "FAILURE") && (
@@ -598,7 +562,7 @@ const TransferTable = ({ schedule, id }) => {
                       </Button>
                     )}
 
-                    {transfer.status == "SCHEDULED" && (
+                    {/* {transfer.status == "SCHEDULED" && (
                       <Button
                         variant="outlined"
                         size="small"
@@ -610,7 +574,7 @@ const TransferTable = ({ schedule, id }) => {
                       >
                         Run Now
                       </Button>
-                    )}
+                    )} */}
                   </TableCell>
                 </TableRow>
               ))}

--- a/web-app/pontoon/src/app/transfers/[id]/page.js
+++ b/web-app/pontoon/src/app/transfers/[id]/page.js
@@ -122,8 +122,21 @@ const TransferDetails = () => {
     return status;
   };
 
-  const transferRunStartTime = transferRun?.meta?.arguments?.mode?.start;
-  const transferRunEndTime = transferRun?.meta?.arguments?.mode?.end;
+  const getDataTransferInterval = (transferMode) => {
+    if (transferMode?.type === "FULL_REFRESH") {
+      return `Full Refresh at ${dayjs(transferRun.created_at)
+        .format("MMM D, h:mm:ss A z")
+        .toString()}`;
+    } else if (transferMode?.type === "INCREMENTAL") {
+      return `${dayjs(transferMode?.start).format(
+        "MMM D, h:mm:ss A z"
+      )} - ${dayjs(transferMode?.end).format("MMM D, h:mm:ss A z")}`;
+    }
+    return "N/A";
+  };
+  const dataTransferInterval = getDataTransferInterval(
+    transferRun?.meta?.arguments?.mode
+  );
 
   const dataForTable = [
     ["Status", getStatus(transferRun.status)],
@@ -141,14 +154,7 @@ const TransferDetails = () => {
       "Transfer Run End Time",
       dayjs(transferRun.modified_at).format("MMM D, h:mm:ss A z").toString(),
     ],
-    [
-      "Data Transfer Interval",
-      transferRunStartTime && transferRunEndTime
-        ? `${dayjs(transferRunStartTime).format("MMM D, h:mm A z")} - ${dayjs(
-            transferRunEndTime
-          ).format("MMM D, h:mm A z")}`
-        : "N/A",
-    ],
+    ["Data Transfer Interval", dataTransferInterval],
     ["Transfer Run ID", transferRun.transfer_run_id],
   ];
 

--- a/web-app/pontoon/src/app/transfers/[id]/page.js
+++ b/web-app/pontoon/src/app/transfers/[id]/page.js
@@ -25,10 +25,14 @@ import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
 import advancedFormat from "dayjs/plugin/advancedFormat";
+import Duration from "dayjs/plugin/duration";
+import RelativeTime from "dayjs/plugin/relativeTime";
 
 dayjs.extend(LocalizedFormat);
 dayjs.extend(timezone);
 dayjs.extend(advancedFormat);
+dayjs.extend(Duration);
+dayjs.extend(RelativeTime);
 
 const TransferDetails = () => {
   const params = useParams();
@@ -118,18 +122,39 @@ const TransferDetails = () => {
     return status;
   };
 
+  const transferRunStartTime = transferRun?.meta?.arguments?.mode?.start;
+  const transferRunEndTime = transferRun?.meta?.arguments?.mode?.end;
+
   const dataForTable = [
-    ["Transfer Run ID", transferRun.transfer_run_id],
-    ["Transfer ID", transferRun.transfer_id],
     ["Status", getStatus(transferRun.status)],
-    ["Created At", dayjs(transferRun.created_at).format("LLL z").toString()],
-    ["Modified At", dayjs(transferRun.modified_at).format("LLL z").toString()],
+    [
+      "Duration",
+      dayjs
+        .duration(dayjs(transferRun.modified_at).diff(transferRun.created_at))
+        .humanize(),
+    ],
+    [
+      "Transfer Run Start Time",
+      dayjs(transferRun.created_at).format("MMM D, h:mm:ss A z").toString(),
+    ],
+    [
+      "Transfer Run End Time",
+      dayjs(transferRun.modified_at).format("MMM D, h:mm:ss A z").toString(),
+    ],
+    [
+      "Data Transfer Interval",
+      transferRunStartTime && transferRunEndTime
+        ? `${dayjs(transferRunStartTime).format("MMM D, h:mm A z")} - ${dayjs(
+            transferRunEndTime
+          ).format("MMM D, h:mm A z")}`
+        : "N/A",
+    ],
+    ["Transfer Run ID", transferRun.transfer_run_id],
   ];
 
   return (
     <DashboardCard
       title={`Transfer Run: ${transferRun.transfer_run_id}`}
-      subtitle={`Status: ${getStatus(transferRun.status)}`}
       topContent={
         <Button
           variant="contained"
@@ -214,7 +239,7 @@ const TransferDetails = () => {
                   </TableCell>
                   <TableCell>
                     <Typography variant="subtitle2" fontWeight={600}>
-                      Created At
+                      Transfer Started At
                     </Typography>
                   </TableCell>
                   <TableCell sx={{ borderTopRightRadius: "5pt" }} />

--- a/web-app/pontoon/src/utils/common.js
+++ b/web-app/pontoon/src/utils/common.js
@@ -100,6 +100,18 @@ export const getScheduleText = (schedule) => {
 };
 
 export const getNextRunTime = (schedule) => {
+  if (schedule.frequency === "HOURLY") {
+    const now = new Date();
+    const nextHour = new Date(now);
+
+    // Increment the hour by 1
+    nextHour.setHours(now.getHours() + 1);
+
+    // Zero out minutes, seconds, milliseconds
+    nextHour.setMinutes(0, 0, 0);
+    return nextHour.toISOString();
+  }
+
   // Set default values for day, hour, and minute
   const day = schedule.day ?? 0; // Default to Sunday if not provided
   const hour = schedule.hour ?? 0; // Default to 0 if not provided


### PR DESCRIPTION
### Front End

- Transfer table in the destination details page revamp
    - Reruns are now grouped together instead of adding a new entry
    - Updated columns to have Start Time, End Time, Duration, and Data Interval
    - Fixed scheduled at bug time showing 7pm
    - Removed "Run now" button from the scheduled run
- Transfer details page
    - Added a section to link to other reruns
    - Added a line for data transfer interval
    - Updated the ordering of fields
- Backfill tab
    - Add a backfill tab for destinations
    - Backfill tab lets you run a customer backfill. Supports full refresh or an incremental refresh for a custom time range

### API

- Added an optional filter for transfers by execution id to get reruns
- Added an override config for running destination to enable custom runs time ranges and backfills
- Added a get endpoint for transfer_id to get details for a transfer_id (mostly for getting a destination from a transfer_id)

### Data Transfer

- Add execution_id as a field that can be set (reruns use the same execution_id)
- Fixed bug with hourly transfers only running the final hour of the day